### PR TITLE
Allow redis config from Pillar data; maxmemory setting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version CURRENT
+
+* Add pillar overrides for key config params
+* Add pillar overrides to limit maxmemory
+
 ## Version 1.0.1
 
 * Add pillar value for turning off save to disk

--- a/redis/etc/redis.conf
+++ b/redis/etc/redis.conf
@@ -15,13 +15,12 @@ maxmemory {{salt['pillar.get']('redis:maxmemory')}}
 maxmemory-policy {{salt['pillar.get']('redis:maxmemory-policy', 'noeviction')}}
 
 {% endif -%}
+{% if salt['pillar.get']('redis:save', True) %}
 ################################ SNAPSHOTTING  #################################
 
-{% if salt['pillar.get']('redis:save', True) %}
 save 900 1
 save 300 10
 save 60 10000
-{% endif %}
 
 rdbcompression yes
 
@@ -29,6 +28,7 @@ dbfilename dump.rdb
 
 dir {{ salt['pillar.get']('redis:dir', '/data/redis') }}
 
+{% endif %}
 ################################# REPLICATION #################################
 
 slave-serve-stale-data yes


### PR DESCRIPTION
Redis without bounds will chew up all the monitoring server memory if there is a major Logstash backlog to process. This adds the ability to limit memory via the maxmemory setting.

In the process, I've created pillar data overrides for common settings. 
