### PR TITLE
Added template logic for old/new redis.conf format

### DIFF
--- a/redis/etc/redis.conf
+++ b/redis/etc/redis.conf
@@ -33,6 +33,9 @@ appendonly no
 appendfsync everysec
 no-appendfsync-on-rewrite no
 
+{%- if grains['osrelease'] == '14.04' %}
+# VIRTUAL MEMORY SECTION REMOVED IN LATEST RELEASE 
+{%- else %}
 ################################ VIRTUAL MEMORY ###############################
 vm-enabled no
 vm-swap-file /var/lib/redis/redis.swap
@@ -40,11 +43,17 @@ vm-max-memory 0
 vm-page-size 32
 vm-pages 134217728
 vm-max-threads 4
+{%- endif %}
 
 ############################### ADVANCED CONFIG ###############################
 
+{%- if grains['osrelease'] == '14.04' %}
+hash-max-ziplist-entries 512
+hash-max-ziplist-value 64
+{%- else %}
 hash-max-zipmap-entries 512
 hash-max-zipmap-value 64
+{%- endif %}
 
 list-max-ziplist-entries 512
 list-max-ziplist-value 64


### PR DESCRIPTION
This change allows the existing redis.conf configuration file to work with the default redis shipped with 
ubuntu 12.04 (pre redis 2.6) and the version shipped with ubuntu 14.04 
