### PR TITLE
Figure out formula name from kitchen configuration

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,8 @@ require 'kitchen'
 require 'fileutils'
 
 namespace :test do
-  Kitchen::Config.new.instances.each do |instance|
+  config = Kitchen::Config.new
+  config.instances.each do |instance|
     case instance.name
       when /vagrant/ 
         desc 'Run Test Kitchen in Vagrant'
@@ -13,7 +14,9 @@ namespace :test do
       when /aws/
         desc 'Run Test Kitchen in AWS'
         task :aws do
-          run_shaker = "salt-shaker shake root_formula=ministryofjustice/#{File.basename(Dir.getwd)}"
+          # "diagnose" method is the only PUBLIC method which will give you a hash of merged configs
+          formula = "#{config.loader.diagnose[:combined_config][:raw_data]["provisioner"]["formula"]}-formula"
+          run_shaker = "salt-shaker shake root_formula=ministryofjustice/#{formula}"
           puts "Resolving formula dependencies: #{run_shaker}"
           sh run_shaker do |ok, res|
             if !ok


### PR DESCRIPTION
This is a bit of a hack as Kitchen does not expose any public methods which would allow you to read MERGED kitchen configuration. This change should be the last piece to get the CI working.
